### PR TITLE
Correctly implement the $ORDER and $DATA database functions; fixes #5

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -82,8 +82,14 @@ that scripts are suggested against long-running transactions.
       given key.
     * `lmdb.Transaction:get(...)` - Get the value located at the given key.
     * `lmdb.Transaction:put(val, ...)` - Put the given value at the given key.
+    * `lmdb.Transaction:next(...)` - Like `order()` below, this function 
+      returns the next lexical node in a given node. Unlike, `order()` 
+      however, this function is _not_ an iterator.
     * `lmdb.Transaction:order(...)` - Order on keys with the given node or
-      nodes as a prefix. Returns the immediate next node value.
+      nodes as a prefix. Returns an iterator that can be used in a generic
+      `for` loop context.
+    * `lmdb.Transaction:iorder(...)` - Exactly the same as `order()` except
+      the first value in the return is an enumeration of the current iteration.
     * `lmdb.Transaction:rollback()` - Roll back any changes made in the
       transaction.
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -78,6 +78,11 @@ that scripts are suggested against long-running transactions.
 * `lmdb.Transaction` - A single LMDB transaction.
     * `lmdb.Transaction:commit()` - Commit any pending changes in the
       transaction.
+    * `lmdb.Transaction:data(...)` - Check to see if there is any data 
+      at the given node or any descendant nodes. Returns 0 if there is no
+      data or children, 1 if there is only data at the specified node, 10
+      if there are only children, and 11 if there is data and the node has
+      children.
     * `lmdb.Transaction:delete(...)` - Delete the value located at the
       given key.
     * `lmdb.Transaction:get(...)` - Get the value located at the given key.

--- a/src/lmdb.c
+++ b/src/lmdb.c
@@ -672,7 +672,7 @@ static int LmdbTx__Dump(lua_State *L) {
 
     // Get the key and value from the db
     MDB_val val;
-    while ((mdb_cursor_get(cur, &key, &val, op)) != MDB_NOTFOUND) {
+    while ((mdb_cursor_get(cur, &key, &val, op)) == 0) {
         // If given a prefix, make sure we stop once we loop past it
         if ((pfxlen > 0) &&
             (strncmp(prefix, (char *)key.mv_data, pfxlen) != 0)) {

--- a/tests/lmdb_test.lua
+++ b/tests/lmdb_test.lua
@@ -186,6 +186,28 @@ function test_tx__dbi()
   tx:close()
 end
 
+function test_tx_data()
+  local tx1 = testdb:begin()
+  tx1:put("", "1A1")
+  tx1:put("", "1B1", "2B1")
+  tx1:put("", "1B1", "2B2")
+  tx1:put("", "1B1", "2B3")
+  tx1:put("", "1C1", "2C1")
+  tx1:put("", "1C1")
+  tx1:put("", "1D1", "2D1", "3D1")
+  tx1:put("", "1D1", "2D1", "3D2")
+  tx1:put("", "1D1", "2D1", "3D3")
+  tx1:put("", "1D1", "2D2")
+  tx1:commit()
+
+  local tx2 = testdb:begin(true)
+  lt:assert_equal(tx2:data("1A0"), 0)
+  lt:assert_equal(tx2:data("1A1"), 1)
+  lt:assert_equal(tx2:data("1D1", "2D1"), 10)
+  lt:assert_equal(tx2:data("1C1"), 11)
+  tx2:rollback()
+end
+
 -- Test that we can delete values and get them back
 function test_tx_delete()
   local tx1 = testdb:begin()
@@ -501,6 +523,7 @@ end)
 
 lt:add_case("txn", function()
   test_tx__dbi()
+  test_tx_data()
   test_tx_delete()
   test_tx_get()
   test_tx_put()


### PR DESCRIPTION
In M, programmers typically traverse the database using the $ORDER primitive function to traverse child nodes of any given database key. Likewise, programmers can use the $DATA primitive to probe a given key for information about whether it or any child nodes contain data. Previously, the LuaDB version of $ORDER did not skip duplicated nodes, which significantly reduced the utility of that function since higher order nodes may have hundreds or thousands of duplicate children. 

This pull request also includes a function, `next()`, which can be used in the same way as `order()` but without requiring an iterator context. I have included Lua-side unit tests to verify that these new changes work and that modifications will not cause regressions.
